### PR TITLE
Fix attachment deletion path

### DIFF
--- a/src/services/attachment.service.ts
+++ b/src/services/attachment.service.ts
@@ -46,8 +46,16 @@ export const deleteAttachments = async (deletedFiles: string[]): Promise<void> =
         const att = await Attachment.findById(id);
         if (!att) continue;
 
-        const filePath = path.join(uploadsDir, att.path);
-        if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+        // att.path is stored with a leading `/uploads/` prefix. Joining this
+        // directly with the uploadsDir would ignore uploadsDir because the path
+        // is absolute. We strip the prefix so that the correct file system path
+        // is constructed under the uploads directory.
+        const relativePath = att.path.replace(/^\/?uploads\//, '');
+        const filePath = path.join(uploadsDir, relativePath);
+
+        if (fs.existsSync(filePath)) {
+            fs.unlinkSync(filePath);
+        }
 
         await att.deleteOne();
     }

--- a/tests/services/attachment.service.test.ts
+++ b/tests/services/attachment.service.test.ts
@@ -1,9 +1,46 @@
+import fs from 'fs';
+import path from 'path';
 import * as attachmentService from '../../src/services/attachment.service';
+import { Attachment } from '../../src/models/attachment.model';
+
+jest.mock('../../src/models/attachment.model');
+jest.mock('fs');
 
 describe('AttachmentService', () => {
   it('returns empty array if no files are passed', async () => {
     const req: any = { files: [] };
     const result = await attachmentService.saveAttachmentsFromRequest(req);
     expect(result).toEqual([]);
+  });
+
+  describe('deleteAttachments', () => {
+    const mockFindById = Attachment.findById as jest.Mock;
+    const unlinkMock = fs.unlinkSync as jest.Mock;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('removes files using the relative path', async () => {
+      const deleteOne = jest.fn();
+      mockFindById.mockResolvedValue({ path: '/uploads/images/test.png', deleteOne });
+      (fs.existsSync as jest.Mock).mockReturnValue(true);
+
+      await attachmentService.deleteAttachments(['fileId']);
+
+      const uploadsDir = path.resolve(process.cwd(), 'src/uploads');
+      const expectedPath = path.join(uploadsDir, 'images/test.png');
+
+      expect(unlinkMock).toHaveBeenCalledWith(expectedPath);
+      expect(deleteOne).toHaveBeenCalled();
+    });
+
+    it('skips when attachment is missing', async () => {
+      mockFindById.mockResolvedValue(null);
+
+      await attachmentService.deleteAttachments(['missingId']);
+
+      expect(unlinkMock).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
## Summary
- fix deletion logic for attachments to use the correct file path
- add tests for `deleteAttachments`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840ca1cee3c832c898a1e6e6d294156