### PR TITLE
Remove debug log from filereader test

### DIFF
--- a/tests/services/filereader.service.test.ts
+++ b/tests/services/filereader.service.test.ts
@@ -28,8 +28,6 @@ describe('extractPdf', () => {
     mockedAxiosPost.mockResolvedValue({ data: mockResult });
 
     const result = await extractPdf(dummyBuffer, dummyFilename);
-    // output the mocked axios post call headers
-    console.log('mockedAxiosPost', mockedAxiosPost.mock.calls[0][2]);
     expect(result).toEqual(mockResult);
     expect(mockedAxiosPost).toHaveBeenCalledWith(
         'http://mock-filereader/extract',


### PR DESCRIPTION
## Summary
- remove stray console.log from `filereader.service.test.ts`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840ce72cd30832c958729f81fb57731