### PR TITLE
fix base url env name

### DIFF
--- a/src/services/attachment.service.ts
+++ b/src/services/attachment.service.ts
@@ -15,7 +15,7 @@ export const saveAttachments = async (files: Express.Multer.File[]): Promise<Att
 
     const baseURL =
         process.env.NODE_ENV === 'production'
-            ? process.env.PRO_BASE_URL
+            ? process.env.PROD_BASE_URL
             : process.env.LOCAL_BASE_URL;
 
     const created = await Promise.all(


### PR DESCRIPTION
## Summary
- use `process.env.PROD_BASE_URL` in `attachment.service`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6840ce5aaaec832cb33bbafa1cf61b81