### PR TITLE
Fix stray shell prompt in catchAsync utility

### DIFF
--- a/src/utils/catchAsync.ts
+++ b/src/utils/catchAsync.ts
@@ -14,4 +14,4 @@ const catchAsync = (fn: AsyncHandler): AsyncHandler => {
 
 export default catchAsync;
 
-// Usage in a route handler
+// Example: router.get('/users', catchAsync(async (req, res) => { /* ... */ }));


### PR DESCRIPTION
## Summary
- clean up comment in `catchAsync.ts`
- add example usage comment

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840ce6c16e4832ca77577a8f4a409d4