### PR TITLE
Add profile routes and controller

### DIFF
--- a/src/controllers/profile.controller.ts
+++ b/src/controllers/profile.controller.ts
@@ -1,0 +1,51 @@
+import { Request, Response } from 'express';
+import httpStatus from 'http-status';
+import catchAsync from '../utils/catchAsync';
+import pick from '../utils/pick';
+import { profileService } from '../services';
+import { QueryUsersFilter } from '../types/user';
+import { QueryProfileOptions } from '../services/profile.service';
+
+export const createProfile = catchAsync(
+    async (req: Request, res: Response) => {
+        const profile = await profileService.createProfile(req.body);
+        res.status(httpStatus.CREATED).send(profile);
+    }
+);
+
+export const getProfiles = catchAsync(
+    async (req: Request, res: Response) => {
+        const filter = pick(req.query, ['name', 'role', 'email']) as QueryUsersFilter;
+        const baseOptions = pick(req.query, ['sortBy', 'limit', 'page']) as QueryProfileOptions;
+        const fields = typeof req.query.fields === 'string'
+            ? req.query.fields.split(',').map((f) => f.trim())
+            : undefined;
+        const options: QueryProfileOptions = { ...baseOptions, fields };
+        const result = await profileService.queryProfiles(filter, options);
+        res.send(result);
+    }
+);
+
+export const getProfile = catchAsync(
+    async (req: Request, res: Response) => {
+        const fields = typeof req.query.fields === 'string'
+            ? req.query.fields.split(',').map((f) => f.trim())
+            : undefined;
+        const profile = await profileService.getProfileById(req.params.profileId, fields);
+        res.send(profile);
+    }
+);
+
+export const updateProfile = catchAsync(
+    async (req: Request, res: Response) => {
+        const profile = await profileService.updateProfileById(req.params.profileId, req.body);
+        res.send(profile);
+    }
+);
+
+export const deleteProfile = catchAsync(
+    async (req: Request, res: Response) => {
+        await profileService.deleteProfileById(req.params.profileId);
+        res.status(httpStatus.NO_CONTENT).send();
+    }
+);

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -6,6 +6,7 @@ import { Payment } from "./payment.model";
 import { Product } from "./product.model";
 import { PurchaseOrder } from "./purchaseOrder.model";
 import { User } from "./user.model";
+import { Profile } from "./profile.model";
 import { Vendor } from "./vendor.model";
 
 export { Attachment };
@@ -16,4 +17,5 @@ export { Payment };
 export { Product };
 export { PurchaseOrder };
 export { User };
+export { Profile };
 export { Vendor };

--- a/src/models/profile.model.ts
+++ b/src/models/profile.model.ts
@@ -1,0 +1,6 @@
+import { User, UserDocument } from './user.model';
+
+export type ProfileDocument = UserDocument;
+
+// Re-export the User model under the Profile name for profile operations
+export const Profile = User;

--- a/src/routes/profile.routes.ts
+++ b/src/routes/profile.routes.ts
@@ -1,0 +1,21 @@
+import { Router } from 'express';
+import {
+    createProfile,
+    getProfiles,
+    getProfile,
+    updateProfile,
+    deleteProfile,
+} from '../controllers/profile.controller';
+
+const router = Router();
+
+router.route('/')
+    .post(createProfile)
+    .get(getProfiles);
+
+router.route('/:profileId')
+    .get(getProfile)
+    .put(updateProfile)
+    .delete(deleteProfile);
+
+export default router;

--- a/src/server.ts
+++ b/src/server.ts
@@ -14,6 +14,7 @@ import clientRoutes from "./routes/client.routes";
 import productRoutes from "./routes/product.routes";
 import purchaseOrderRoutes from "./routes/purchaseOrder.routes";
 import paymentRoutes from "./routes/payment.routes";
+import profileRoutes from "./routes/profile.routes";
 import { prepareBodyForApi } from "./utils/formDataHandler";
 
 dotenv.config();
@@ -71,6 +72,7 @@ app.use("/api/payment", paymentRoutes);
 app.use("/api/product", productRoutes);
 app.use("/api/purchaseOrder", purchaseOrderRoutes);
 app.use("/api/vendor", vendorRoutes);
+app.use("/api/profile", profileRoutes);
 
 app.get("/", (req, res) => {
     res.json({ message: "alive" });


### PR DESCRIPTION
## Summary
- add `Profile` model alias
- expose Profile model in models index
- implement profile controller and routes
- register `/api/profile` routes in server

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857913f200c832ca256acda2cb62268