### PR TITLE
Add payment type API

### DIFF
--- a/src/controllers/paymentType.controller.ts
+++ b/src/controllers/paymentType.controller.ts
@@ -1,0 +1,35 @@
+import { Request, Response } from 'express';
+import httpStatus from 'http-status';
+import catchAsync from '../utils/catchAsync';
+import { paymentTypeService } from '../services';
+import pick from '../utils/pick';
+import { QueryPaymentTypeFilter, CreatePaymentTypeInput, UpdatePaymentTypeInput } from '../types/paymentType';
+import { QueryOptions } from '../types/common';
+
+export const createPaymentType = catchAsync(async (req: Request, res: Response) => {
+    const body = req.body as CreatePaymentTypeInput;
+    const paymentType = await paymentTypeService.createPaymentType(body);
+    res.status(httpStatus.CREATED).send({ paymentType });
+});
+
+export const getPaymentTypes = catchAsync(async (req: Request, res: Response) => {
+    const filter = pick(req.query, ['name', 'clientId']) as QueryPaymentTypeFilter;
+    const options = pick(req.query, ['sortBy', 'limit', 'page']) as QueryOptions;
+    const result = await paymentTypeService.queryPaymentTypes(filter, options);
+    res.send(result);
+});
+
+export const getPaymentTypeById = catchAsync(async (req: Request, res: Response) => {
+    const paymentType = await paymentTypeService.getPaymentTypeById(req.params.id);
+    res.send({ paymentType });
+});
+
+export const updatePaymentType = catchAsync(async (req: Request, res: Response) => {
+    const paymentType = await paymentTypeService.updatePaymentType(req.params.id, req.body as UpdatePaymentTypeInput);
+    res.send({ paymentType });
+});
+
+export const deletePaymentType = catchAsync(async (req: Request, res: Response) => {
+    await paymentTypeService.deletePaymentType(req.params.id);
+    res.status(httpStatus.OK).send();
+});

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -8,6 +8,7 @@ import { PurchaseOrder } from "./purchaseOrder.model";
 import { User } from "./user.model";
 import { Profile } from "./profile.model";
 import { Vendor } from "./vendor.model";
+import { PaymentType } from './paymentType.model';
 
 export { Attachment };
 export { Bill };
@@ -19,3 +20,4 @@ export { PurchaseOrder };
 export { User };
 export { Profile };
 export { Vendor };
+export { PaymentType };

--- a/src/models/paymentType.model.ts
+++ b/src/models/paymentType.model.ts
@@ -1,0 +1,40 @@
+import mongoose, { Document, Model, Schema } from 'mongoose';
+import { paginate } from '../utils/plugins';
+
+export interface IPaymentType {
+    name: string;
+    lastFour: string;
+    clientId: mongoose.Types.ObjectId;
+}
+
+export interface PaymentTypeDocument extends IPaymentType, Document {}
+
+export interface PaymentTypeModel<T extends Document> extends Model<T> {
+    paginate(filter: any, options: any): Promise<any>;
+}
+
+const paymentTypeSchema = new Schema<PaymentTypeDocument>(
+    {
+        name: { type: String, required: true, trim: true },
+        lastFour: { type: String, required: true },
+        clientId: { type: mongoose.Schema.Types.ObjectId, ref: 'Client', required: true },
+    },
+    { timestamps: true }
+);
+
+paymentTypeSchema.plugin(paginate);
+
+paymentTypeSchema.set('toJSON', {
+    virtuals: true,
+    transform(_doc, ret) {
+        ret.id = ret._id;
+        delete ret._id;
+        delete ret.__v;
+        ret.displayName = `${ret.name} ${ret.name.toLowerCase().includes('bank') ? '****' + ret.lastFour : 'ending in ' + ret.lastFour}`;
+    },
+});
+
+export const PaymentType = mongoose.model<PaymentTypeDocument, PaymentTypeModel<PaymentTypeDocument>>(
+    'PaymentType',
+    paymentTypeSchema
+);

--- a/src/routes/paymentType.routes.ts
+++ b/src/routes/paymentType.routes.ts
@@ -1,0 +1,21 @@
+import { Router } from 'express';
+import {
+    createPaymentType,
+    getPaymentTypes,
+    getPaymentTypeById,
+    updatePaymentType,
+    deletePaymentType,
+} from '../controllers/paymentType.controller';
+
+const router = Router();
+
+router.route('/')
+    .post(createPaymentType)
+    .get(getPaymentTypes);
+
+router.route('/:id')
+    .get(getPaymentTypeById)
+    .put(updatePaymentType)
+    .delete(deletePaymentType);
+
+export default router;

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,6 +15,7 @@ import productRoutes from "./routes/product.routes";
 import purchaseOrderRoutes from "./routes/purchaseOrder.routes";
 import paymentRoutes from "./routes/payment.routes";
 import profileRoutes from "./routes/profile.routes";
+import paymentTypeRoutes from "./routes/paymentType.routes";
 import { prepareBodyForApi } from "./utils/formDataHandler";
 
 dotenv.config();
@@ -71,6 +72,7 @@ app.use("/api/filereader", filereaderRoutes);
 app.use("/api/payment", paymentRoutes);
 app.use("/api/product", productRoutes);
 app.use("/api/purchaseOrder", purchaseOrderRoutes);
+app.use("/api/paymentType", paymentTypeRoutes);
 app.use("/api/vendor", vendorRoutes);
 app.use("/api/profile", profileRoutes);
 

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -9,6 +9,7 @@ import * as purchaseOrderService from './purchaseOrder.service';
 import * as userService from './user.service';
 import * as profileService from './profile.service';
 import * as vendorService from './vendor.service';
+import * as paymentTypeService from './paymentType.service';
 
 export { attachmentService };
 export { billService };
@@ -21,3 +22,4 @@ export { purchaseOrderService };
 export { userService };
 export { profileService };
 export { vendorService };
+export { paymentTypeService };

--- a/src/services/paymentType.service.ts
+++ b/src/services/paymentType.service.ts
@@ -1,0 +1,52 @@
+import httpStatus from 'http-status';
+import ApiError from '../utils/ApiError';
+import { PaymentType, PaymentTypeDocument } from '../models/paymentType.model';
+import { Client } from '../models/client.model';
+import {
+    CreatePaymentTypeInput,
+    UpdatePaymentTypeInput,
+    QueryPaymentTypeFilter,
+} from '../types/paymentType';
+import { QueryOptions } from '../types/common';
+
+export const createPaymentType = async (
+    body: CreatePaymentTypeInput
+): Promise<PaymentTypeDocument> => {
+    const client = await Client.findById(body.clientId);
+    if (!client) throw new ApiError(httpStatus.NOT_FOUND, 'Client not found');
+    return PaymentType.create(body);
+};
+
+export const queryPaymentTypes = async (
+    filter: QueryPaymentTypeFilter,
+    options: QueryOptions
+) => {
+    const newFilter: any = {};
+    if (filter.name) newFilter.name = { $regex: new RegExp(filter.name, 'i') };
+    if (filter.clientId) newFilter.clientId = filter.clientId;
+    return PaymentType.paginate(newFilter, options);
+};
+
+export const getPaymentTypeById = async (
+    id: string
+): Promise<PaymentTypeDocument> => {
+    const paymentType = await PaymentType.findById(id);
+    if (!paymentType) throw new ApiError(httpStatus.NOT_FOUND, 'Payment type not found');
+    return paymentType;
+};
+
+export const updatePaymentType = async (
+    id: string,
+    updateBody: UpdatePaymentTypeInput
+): Promise<PaymentTypeDocument> => {
+    const paymentType = await PaymentType.findById(id);
+    if (!paymentType) throw new ApiError(httpStatus.NOT_FOUND, 'Payment type not found');
+    Object.assign(paymentType, updateBody);
+    await paymentType.save();
+    return paymentType;
+};
+
+export const deletePaymentType = async (id: string): Promise<void> => {
+    const removed = await PaymentType.findByIdAndDelete(id);
+    if (!removed) throw new ApiError(httpStatus.NOT_FOUND, 'Payment type not found');
+};

--- a/src/types/paymentType.ts
+++ b/src/types/paymentType.ts
@@ -1,0 +1,21 @@
+import { Types } from 'mongoose';
+import { QueryOptions } from './common';
+
+export interface PaymentTypeAttributes {
+    name: string;
+    lastFour: string;
+    clientId: Types.ObjectId;
+}
+
+export interface CreatePaymentTypeInput {
+    name: string;
+    lastFour: string;
+    clientId: string;
+}
+
+export interface UpdatePaymentTypeInput extends Partial<CreatePaymentTypeInput> {}
+
+export interface QueryPaymentTypeFilter {
+    name?: string;
+    clientId?: string;
+}

--- a/tests/services/paymentType.service.test.ts
+++ b/tests/services/paymentType.service.test.ts
@@ -1,0 +1,102 @@
+import {
+  createPaymentType,
+  queryPaymentTypes,
+  getPaymentTypeById,
+  updatePaymentType,
+  deletePaymentType
+} from '../../src/services/paymentType.service';
+import { PaymentType, Client } from '../../src/models';
+
+jest.mock('../../src/models/paymentType.model');
+jest.mock('../../src/models/client.model');
+
+describe('createPaymentType', () => {
+  const mockFindClient = Client.findById as jest.Mock;
+  const mockCreate = PaymentType.create as jest.Mock;
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('creates payment type when client exists', async () => {
+    const input = { name: 'Credit Card', lastFour: '1234', clientId: 'c1' };
+    mockFindClient.mockResolvedValue({ _id: 'c1' });
+    mockCreate.mockResolvedValue({ _id: 'pt1', ...input });
+
+    const result = await createPaymentType(input);
+    expect(result).toHaveProperty('_id', 'pt1');
+    expect(mockCreate).toHaveBeenCalledWith(input);
+  });
+
+  it('throws if client not found', async () => {
+    mockFindClient.mockResolvedValue(null);
+    await expect(createPaymentType({ name: 'x', lastFour: '1111', clientId: 'bad' }))
+      .rejects.toThrow('Client not found');
+  });
+});
+
+describe('queryPaymentTypes', () => {
+  const mockPaginate = PaymentType.paginate as jest.Mock;
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('applies filters correctly', async () => {
+    mockPaginate.mockResolvedValue({ docs: [] });
+    await queryPaymentTypes({ name: 'Credit' }, { page: 1, limit: 5 });
+    expect(mockPaginate).toHaveBeenCalledWith(
+      { name: { $regex: expect.any(RegExp) } },
+      expect.objectContaining({ page: 1, limit: 5 })
+    );
+  });
+});
+
+describe('getPaymentTypeById', () => {
+  const mockFindById = PaymentType.findById as jest.Mock;
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns payment type if found', async () => {
+    mockFindById.mockResolvedValue({ _id: 'pt1' });
+    const result = await getPaymentTypeById('pt1');
+    expect(result).toHaveProperty('_id', 'pt1');
+  });
+
+  it('throws if not found', async () => {
+    mockFindById.mockResolvedValue(null);
+    await expect(getPaymentTypeById('bad')).rejects.toThrow('Payment type not found');
+  });
+});
+
+describe('updatePaymentType', () => {
+  const mockFindById = PaymentType.findById as jest.Mock;
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('updates and saves payment type', async () => {
+    const save = jest.fn();
+    const pt = { _id: 'pt1', name: 'Old', save };
+    mockFindById.mockResolvedValue(pt);
+    const result = await updatePaymentType('pt1', { name: 'New' });
+    expect(result.name).toBe('New');
+    expect(save).toHaveBeenCalled();
+  });
+
+  it('throws if not found', async () => {
+    mockFindById.mockResolvedValue(null);
+    await expect(updatePaymentType('bad', {})).rejects.toThrow('Payment type not found');
+  });
+});
+
+describe('deletePaymentType', () => {
+  const mockDelete = PaymentType.findByIdAndDelete as jest.Mock;
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('deletes payment type', async () => {
+    mockDelete.mockResolvedValue({ _id: 'pt1' });
+    await expect(deletePaymentType('pt1')).resolves.toBeUndefined();
+  });
+
+  it('throws if not found', async () => {
+    mockDelete.mockResolvedValue(null);
+    await expect(deletePaymentType('bad')).rejects.toThrow('Payment type not found');
+  });
+});


### PR DESCRIPTION
## Summary
- create model for payment types
- CRUD service and controller logic
- expose routes and wire into server
- update service/model exports
- add tests for payment type service

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f4ce12b44832cbd787c04b34f47e1