### PR TITLE
Expose last 4 digits on payment type

### DIFF
--- a/src/controllers/paymentType.controller.ts
+++ b/src/controllers/paymentType.controller.ts
@@ -13,7 +13,7 @@ export const createPaymentType = catchAsync(async (req: Request, res: Response) 
 });
 
 export const getPaymentTypes = catchAsync(async (req: Request, res: Response) => {
-    const filter = pick(req.query, ['name', 'clientId']) as QueryPaymentTypeFilter;
+    const filter = pick(req.query, ['name', 'type', 'clientId']) as QueryPaymentTypeFilter;
     const options = pick(req.query, ['sortBy', 'limit', 'page']) as QueryOptions;
     const result = await paymentTypeService.queryPaymentTypes(filter, options);
     res.send(result);

--- a/src/models/paymentType.model.ts
+++ b/src/models/paymentType.model.ts
@@ -5,6 +5,7 @@ export interface IPaymentType {
     name: string;
     /** full card or account number */
     details: string;
+    type: 'credit_card' | 'debit_card' | 'bank_account';
     clientId: mongoose.Types.ObjectId;
 }
 
@@ -18,6 +19,11 @@ const paymentTypeSchema = new Schema<PaymentTypeDocument>(
     {
         name: { type: String, required: true, trim: true },
         details: { type: String, required: true },
+        type: {
+            type: String,
+            enum: ['credit_card', 'debit_card', 'bank_account'],
+            required: true,
+        },
         clientId: { type: mongoose.Schema.Types.ObjectId, ref: 'Client', required: true },
     },
     { timestamps: true }
@@ -33,6 +39,7 @@ paymentTypeSchema.set('toJSON', {
         delete ret.__v;
         const lastFour = ret.details.slice(-4);
         ret.displayName = `${ret.name} ${ret.name.toLowerCase().includes('bank') ? '****' + lastFour : 'ending in ' + lastFour}`;
+        ret.endingCardNumber = lastFour;
         delete ret.details;
     },
 });

--- a/src/services/paymentType.service.ts
+++ b/src/services/paymentType.service.ts
@@ -23,6 +23,7 @@ export const queryPaymentTypes = async (
 ) => {
     const newFilter: any = {};
     if (filter.name) newFilter.name = { $regex: new RegExp(filter.name, 'i') };
+    if (filter.type) newFilter.type = filter.type;
     if (filter.clientId) newFilter.clientId = filter.clientId;
     return PaymentType.paginate(newFilter, options);
 };

--- a/src/types/paymentType.ts
+++ b/src/types/paymentType.ts
@@ -1,10 +1,13 @@
 import { Types } from 'mongoose';
 import { QueryOptions } from './common';
 
+export type PaymentMethodType = 'credit_card' | 'debit_card' | 'bank_account';
+
 export interface PaymentTypeAttributes {
     name: string;
     /** full card or account number */
     details: string;
+    type: PaymentMethodType;
     clientId: Types.ObjectId;
 }
 
@@ -12,6 +15,7 @@ export interface CreatePaymentTypeInput {
     name: string;
     /** full card or account number */
     details: string;
+    type: PaymentMethodType;
     clientId: string;
 }
 
@@ -19,5 +23,6 @@ export interface UpdatePaymentTypeInput extends Partial<CreatePaymentTypeInput> 
 
 export interface QueryPaymentTypeFilter {
     name?: string;
+    type?: PaymentMethodType;
     clientId?: string;
 }

--- a/tests/services/paymentType.service.test.ts
+++ b/tests/services/paymentType.service.test.ts
@@ -6,6 +6,7 @@ import {
   deletePaymentType
 } from '../../src/services/paymentType.service';
 import { PaymentType, Client } from '../../src/models';
+import { CreatePaymentTypeInput } from '../../src/types/paymentType';
 
 jest.mock('../../src/models/paymentType.model');
 jest.mock('../../src/models/client.model');
@@ -17,7 +18,7 @@ describe('createPaymentType', () => {
   beforeEach(() => jest.clearAllMocks());
 
   it('creates payment type when client exists', async () => {
-    const input = { name: 'Credit Card', details: '4111111111111234', clientId: 'c1' };
+    const input: CreatePaymentTypeInput = { name: 'Credit Card', details: '4111111111111234', type: 'credit_card', clientId: 'c1' };
     mockFindClient.mockResolvedValue({ _id: 'c1' });
     mockCreate.mockResolvedValue({ _id: 'pt1', ...input });
 
@@ -28,7 +29,7 @@ describe('createPaymentType', () => {
 
   it('throws if client not found', async () => {
     mockFindClient.mockResolvedValue(null);
-    await expect(createPaymentType({ name: 'x', details: '0000111122223333', clientId: 'bad' }))
+    await expect(createPaymentType({ name: 'x', details: '0000111122223333', type: 'credit_card', clientId: 'bad' } as CreatePaymentTypeInput))
       .rejects.toThrow('Client not found');
   });
 });
@@ -40,9 +41,9 @@ describe('queryPaymentTypes', () => {
 
   it('applies filters correctly', async () => {
     mockPaginate.mockResolvedValue({ docs: [] });
-    await queryPaymentTypes({ name: 'Credit' }, { page: 1, limit: 5 });
+    await queryPaymentTypes({ name: 'Credit', type: 'credit_card' }, { page: 1, limit: 5 });
     expect(mockPaginate).toHaveBeenCalledWith(
-      { name: { $regex: expect.any(RegExp) } },
+      { name: { $regex: expect.any(RegExp) }, type: 'credit_card' },
       expect.objectContaining({ page: 1, limit: 5 })
     );
   });
@@ -72,7 +73,7 @@ describe('updatePaymentType', () => {
 
   it('updates and saves payment type', async () => {
     const save = jest.fn();
-    const pt = { _id: 'pt1', name: 'Old', save };
+    const pt = { _id: 'pt1', name: 'Old', type: 'credit_card', save };
     mockFindById.mockResolvedValue(pt);
     const result = await updatePaymentType('pt1', { name: 'New' });
     expect(result.name).toBe('New');


### PR DESCRIPTION
## Summary
- include last four digits of the card number as `endingCardNumber`
- add enumerated `type` field for payment methods

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687066657b10832caa36885193f3db0c