### PR TITLE
Add paymentType support to payment API

### DIFF
--- a/src/controllers/payment.controller.ts
+++ b/src/controllers/payment.controller.ts
@@ -16,6 +16,7 @@ export const createPayment = catchAsync(async (req: Request, res: Response) => {
             {
                 bills,
                 paymentMethod: rawBody.paymentMethod,
+                paymentType: rawBody.paymentType,
                 clientId: rawBody.clientId,
                 notes: rawBody.notes,
             },
@@ -31,7 +32,7 @@ export const createPayment = catchAsync(async (req: Request, res: Response) => {
 });
 
 export const getPayments = catchAsync(async (req: Request, res: Response) => {
-    const filter = pick(req.query, ['bill', 'status', 'paymentMethod', 'clientId', 'minAmount', 'maxAmount']) as PaymentFilter;
+    const filter = pick(req.query, ['bill', 'status', 'paymentMethod', 'paymentType', 'clientId', 'minAmount', 'maxAmount']) as PaymentFilter;
     const options = pick(req.query, ['sortBy', 'limit', 'page']);
     const result = await paymentService.queryPayments(filter, options);
     res.send({ docs: result.docs, ...result });

--- a/src/models/payment.model.ts
+++ b/src/models/payment.model.ts
@@ -6,6 +6,7 @@ export interface IPayment {
     amount: number;
     discount: number;
     paymentMethod: 'card' | 'bank_transfer' | 'cash' | 'check' | 'ach' | 'wire_transfer';
+    paymentType?: mongoose.Types.ObjectId;
     status?: 'paid' | 'unpaid';
     paymentDate?: Date;
     notes?: string;
@@ -32,6 +33,7 @@ const paymentSchema = new Schema<PaymentDocument>(
             enum: ['card', 'bank_transfer', 'cash', 'check', 'ach', 'wire_transfer'],
             required: true,
         },
+        paymentType: { type: mongoose.Schema.Types.ObjectId, ref: 'PaymentType' },
         status: { type: String, enum: ['paid', 'unpaid'], default: 'paid' },
         paymentDate: { type: Date, default: Date.now },
         notes: { type: String, trim: true },

--- a/src/services/payment.service.ts
+++ b/src/services/payment.service.ts
@@ -110,6 +110,7 @@ export const createPayments = async (
             bill: item.bill,
             amount: item.amount,
             paymentMethod: body.paymentMethod,
+            paymentType: body.paymentType,
             clientId: body.clientId,
             notes: body.notes,
         };
@@ -126,6 +127,7 @@ export const queryPayments = async (filter: any, options: any) => {
     if (minAmount && maxAmount) newFilter.amount = { $gte: minAmount, $lte: maxAmount };
     else if (minAmount) newFilter.amount = { $gte: minAmount };
     else if (maxAmount) newFilter.amount = { $lte: maxAmount };
+    if (filter.paymentType) newFilter.paymentType = filter.paymentType;
     return Payment.paginate(newFilter, { ...options, populate: 'bill attachments' });
 };
 

--- a/src/types/payment.ts
+++ b/src/types/payment.ts
@@ -2,6 +2,7 @@ export interface PaymentFilter {
     bill?: string;
     status?: 'paid' | 'unpaid';
     paymentMethod?: 'card' | 'bank_transfer' | 'cash' | 'check' | 'ach' | 'wire_transfer';
+    paymentType?: string;
     clientId?: string;
     minAmount?: number;
     maxAmount?: number;
@@ -12,6 +13,7 @@ export interface CreatePaymentInput {
     amount: number;
     discount?: number;
     paymentMethod: string;
+    paymentType?: string;
     status?: string;
     paymentDate?: Date;
     notes?: string;
@@ -27,6 +29,7 @@ export interface PaymentItem {
 export interface CreateMultiplePaymentsInput {
     bills: PaymentItem[];
     paymentMethod: string;
+    paymentType?: string;
     clientId: string;
     notes?: string;
 }


### PR DESCRIPTION
## Summary
- support `paymentType` field when creating or querying payments
- persist `paymentType` reference in the Payment model

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6871a7c4253c832c98b098a73fadb9e0